### PR TITLE
Add permissions to workflows

### DIFF
--- a/.github/workflows/update-readme.yaml
+++ b/.github/workflows/update-readme.yaml
@@ -11,6 +11,9 @@ concurrency:
   group: check-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add explicit `permissions: contents: read` to workflow files
- Satisfies the `actions/missing-workflow-permissions` code scanning rule
